### PR TITLE
Fix message deletion on /votekick

### DIFF
--- a/main.py
+++ b/main.py
@@ -291,10 +291,11 @@ def votekick(update: Update, context: CallbackContext):
 			f'User {get_mention(target)} now has {votes}/3 votes against them\\.{appendix}',
 			parse_mode=ParseMode.MARKDOWN_V2)
 		if votes >= 3:
-			# NOTE: deleting all messages from a user is a bit harsh, since it's irreversible, but
-			# /votekick has worked well and hasn't been abused so far. As it's mostly used to combat
-			# spam, enabling this seems fine.
-			context.bot.ban_chat_member(chat_id=chat.id, user_id=target.id, revoke_messages=True)
+			context.bot.ban_chat_member(chat_id=chat.id, user_id=target.id)
+			# NOTE: bot API doesn't support deleting all messages by a user, so we only delete the last
+			# message. Thi is irreversible, but /votekick has worked well and hasn't been abused so far. As
+			# it's mostly used to combat spam, enabling this seems fine.
+			update.message.reply_to_message.delete()
 
 
 print("starting polling")


### PR DESCRIPTION
revoke_messages doesn't do what we thought it did. This fix only deletes one message, but that's likely enough.