### PR TITLE
feat: transition to link-based spam detection

### DIFF
--- a/common.py
+++ b/common.py
@@ -3,7 +3,7 @@ from sys import stderr
 from typing import Optional
 from collections.abc import Callable
 from hashlib import md5
-from url_normalize import url_normalize
+from urllib.parse import urlparse, urlunparse
 
 from telegram import Chat, Update, User, Message, Bot, MessageEntity
 from telegram.constants import ParseMode
@@ -126,16 +126,12 @@ async def kick_message(
 
 				# autofiltering stuff
 				if link_badness >= CONFIG['spam_threshhold']:
-					kept_links: list[tuple[int, bytes, int]] = []
 					for message_id, recent_link_hash, userid in recent_message_links:
 						if recent_link_hash == link_hash:
 							link_badness += 1
 							messages_to_delete.add(message_id)
 							users_to_ban.add(userid)
 							autofiltered += 1
-						else:
-							kept_links.append((message_id, recent_link_hash, userid))
-					recent_message_links[:] = kept_links
 
 				db.set_message_badness(link_hash, link_badness)
 			if autofiltered > 0:
@@ -184,8 +180,17 @@ def get_urls_from_message(message: Message) -> list[str]:
 			user_link = f"https://t.me/{username}"
 			urls.append(user_link)
 
-	normalized_urls = [norm.replace("http://", "https://", 1) if norm.startswith("http://") else norm for url in urls if (norm := url_normalize(url)) is not None]
+	normalized_urls = [normalize_url(url) for url in urls if url]
 	return normalized_urls
+
+def normalize_url(url: str) -> str:
+	if not url:
+		return url
+	parsed = urlparse(url)
+	if parsed.scheme == '' or parsed.scheme == "http":
+		parsed = parsed._replace(scheme='https')
+	parsed = parsed._replace(netloc=parsed.netloc.lower())
+	return urlunparse(parsed)
 
 def get_entity_string(message_text: str, entity: MessageEntity) -> str:
 	utf_16_message_bytes = message_text.encode('utf-16-le')

--- a/common.py
+++ b/common.py
@@ -3,6 +3,7 @@ from sys import stderr
 from typing import Optional
 from collections.abc import Callable
 from hashlib import md5
+from url_normalize import url_normalize
 
 from telegram import Chat, Update, User, Message, Bot, MessageEntity
 from telegram.constants import ParseMode
@@ -182,7 +183,8 @@ def get_urls_from_message(message: Message) -> list[str]:
 			username = get_entity_string(message.text, entity)[1:]
 			user_link = f"https://t.me/{username}"
 			urls.append(user_link)
-	return urls
+
+	return [normalized for url in urls if (normalized := url_normalize(url)) is not None]
 
 def get_entity_string(message_text: str, entity: MessageEntity) -> str:
 	utf_16_message_bytes = message_text.encode('utf-16-le')

--- a/common.py
+++ b/common.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 from sys import stderr
-from typing import Optional
+from typing import List, Optional, Tuple
 from collections.abc import Callable
 from hashlib import md5
 
-from telegram import Chat, Update, User, Message, Bot
+from telegram import Chat, Update, User, Message, Bot, MessageEntity
 from telegram.constants import ParseMode
 from telegram.helpers import escape_markdown
 from telegram.ext import CallbackContext
@@ -13,7 +13,7 @@ from telegram.error import BadRequest, TelegramError
 import database
 from config import CONFIG
 
-recent_messages: list[tuple[int, bytes, int]] = []
+recent_message_links: list[tuple[int, bytes, int]] = [] # message_id, link_hash, userid
 
 def escape_md(txt: str) -> str:
 	return escape_markdown(txt, 2)
@@ -91,16 +91,7 @@ async def check_admin_to_user_action(message: Message, command: str, usable_on_b
 	return tuser
 
 def remove_from_recent_messages(*args: int) -> None:
-	c = len(args)
-	# reverse iterate over list, so we can remove per-index without accounting for any offsets
-	for i in reversed(range(len(recent_messages))):
-		if recent_messages[i][0] in args:
-			recent_messages.pop(i)
-			c -= 1
-
-			# found all messages to delete, exit loop
-			if c <= 0:
-				break
+	recent_message_links[:] = [link for link in recent_message_links if link[0] not in args]
 
 async def kick_message(
 	message: Message,
@@ -112,48 +103,53 @@ async def kick_message(
 	Removes a message, bans the user, and does all the necessary autofiltering stuff
 	'''
 	assert message.from_user is not None
-	toban = set([message.from_user.id])
-	todel = set([message.id])
+	users_to_ban = set([message.from_user.id])
+	messages_to_delete = set([message.id])
 
 	# immediately delete any messages associated with this votekick to unclog chat
-	todel.update(db.pop_vk_messages(message.from_user.id))
+	messages_to_delete.update(db.pop_vk_messages(message.from_user.id))
 	# get rid of deleted messages in memory so we can remember more potentially important messages
-	remove_from_recent_messages(*todel)
+	remove_from_recent_messages(*messages_to_delete)
 	try:
 		if message.text is not None and len(message.text) >= CONFIG['spam_minlength']:
-			thisdigest = hashdigest(message.text)
-			badness = db.check_message_badness(thisdigest)
-
-			if mark_as_spam:
-				badness += CONFIG['spam_threshhold']
-			else:
-				badness += 1
-
 			autofiltered = 0
-			# autofiltering stuff
-			if badness >= CONFIG['spam_threshhold']:
-				for i in reversed(range(len(recent_messages))):
-					msgid, digest, userid = recent_messages[i]
-					if digest == thisdigest:
-						badness += 1
-						todel.add(msgid)
-						toban.add(userid)
-						del recent_messages[i]
-						autofiltered += 1
+			message_links: List[str] = get_urls_from_message(message)
+			for link in message_links:
+				link_hash = hashdigest(link)
+				link_badness = db.check_message_badness(link_hash)
 
-			db.set_message_badness(thisdigest, badness)
+				if mark_as_spam:
+					link_badness += CONFIG['spam_threshhold']
+				else:
+					link_badness += 1
+
+				# autofiltering stuff
+				if link_badness >= CONFIG['spam_threshhold']:
+					kept_links: List[Tuple[int, bytes, int]] = []
+					for message_id, recent_link_hash, userid in recent_message_links:
+						if recent_link_hash == link_hash:
+							link_badness += 1
+							messages_to_delete.add(message_id)
+							users_to_ban.add(userid)
+							autofiltered += 1
+						else:
+							kept_links.append((message_id, recent_link_hash, userid))
+					recent_message_links[:] = kept_links
+
+				db.set_message_badness(link_hash, link_badness)
 			if autofiltered > 0:
 				plural = 's' if autofiltered >= 2 else ''
 				await context.bot.send_message(message.chat.id, f"cleared {autofiltered} additional spam message{plural}")
+			remove_from_recent_messages(*messages_to_delete)
 	finally:
-		for userid in toban:
+		for userid in users_to_ban:
 			await ban_user(context, message.chat.id, userid, message.sender_chat)
-		for msgid in todel:
+		for message_id in messages_to_delete:
 			try:
-				await context.bot.delete_message(message.chat.id, msgid)
+				await context.bot.delete_message(message.chat.id, message_id)
 			except BadRequest as e:
 				# we couldn't delete this message; no biggie. There's lots of weird restrictions on what messages can be deleted.
-				print(f"couldn't delete message {userid}: {e.message}", file=stderr)
+				print(f"couldn't delete message {message_id}: {e.message}", file=stderr)
 
 async def ban_user(context: CallbackContext, chatid: int, userid: int, sender_chat: Chat | None) -> None:
 	pass # ban_chat_sender_chat
@@ -169,6 +165,21 @@ async def ban_user(context: CallbackContext, chatid: int, userid: int, sender_ch
 		await ban
 	except TelegramError as e:
 		print(f"couldn't ban {'channel' if ischannel else 'user'} {banid} ({e.message})", file=stderr)
+
+def get_urls_from_message(message: Message) -> List[str]:
+	urls: List[str] = []
+	if not message.entities or not message.text:
+		return urls
+	utf_16_message_bytes = message.text.encode('utf-16-le')
+	for entity in message.entities:
+		if entity.type == MessageEntity.URL:
+			start_byte = entity.offset * 2
+			end_byte = start_byte + entity.length * 2
+			utf_16_link_bytes = utf_16_message_bytes[start_byte:end_byte]
+			urls.append(utf_16_link_bytes.decode('utf-16-le'))
+		if entity.type == MessageEntity.TEXT_LINK and entity.url is not None:
+			urls.append(entity.url)
+	return urls
 
 class LBUser:
 	__slot__ = ('score', 'rank', 'userid')

--- a/common.py
+++ b/common.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 from sys import stderr
-from typing import List, Optional, Tuple
+from typing import Optional
 from collections.abc import Callable
 from hashlib import md5
 
@@ -103,8 +103,8 @@ async def kick_message(
 	Removes a message, bans the user, and does all the necessary autofiltering stuff
 	'''
 	assert message.from_user is not None
-	users_to_ban = set([message.from_user.id])
-	messages_to_delete = set([message.id])
+	users_to_ban = {message.from_user.id}
+	messages_to_delete = {message.id}
 
 	# immediately delete any messages associated with this votekick to unclog chat
 	messages_to_delete.update(db.pop_vk_messages(message.from_user.id))
@@ -113,7 +113,7 @@ async def kick_message(
 	try:
 		if message.text is not None and len(message.text) >= CONFIG['spam_minlength']:
 			autofiltered = 0
-			message_links: List[str] = get_urls_from_message(message)
+			message_links: list[str] = get_urls_from_message(message)
 			for link in message_links:
 				link_hash = hashdigest(link)
 				link_badness = db.check_message_badness(link_hash)
@@ -125,7 +125,7 @@ async def kick_message(
 
 				# autofiltering stuff
 				if link_badness >= CONFIG['spam_threshhold']:
-					kept_links: List[Tuple[int, bytes, int]] = []
+					kept_links: list[tuple[int, bytes, int]] = []
 					for message_id, recent_link_hash, userid in recent_message_links:
 						if recent_link_hash == link_hash:
 							link_badness += 1
@@ -140,8 +140,8 @@ async def kick_message(
 			if autofiltered > 0:
 				plural = 's' if autofiltered >= 2 else ''
 				await context.bot.send_message(message.chat.id, f"cleared {autofiltered} additional spam message{plural}")
-			remove_from_recent_messages(*messages_to_delete)
 	finally:
+		remove_from_recent_messages(*messages_to_delete)
 		for userid in users_to_ban:
 			await ban_user(context, message.chat.id, userid, message.sender_chat)
 		for message_id in messages_to_delete:
@@ -166,20 +166,29 @@ async def ban_user(context: CallbackContext, chatid: int, userid: int, sender_ch
 	except TelegramError as e:
 		print(f"couldn't ban {'channel' if ischannel else 'user'} {banid} ({e.message})", file=stderr)
 
-def get_urls_from_message(message: Message) -> List[str]:
-	urls: List[str] = []
+def get_urls_from_message(message: Message) -> list[str]:
+	urls: list[str] = []
 	if not message.entities or not message.text:
 		return urls
-	utf_16_message_bytes = message.text.encode('utf-16-le')
 	for entity in message.entities:
 		if entity.type == MessageEntity.URL:
-			start_byte = entity.offset * 2
-			end_byte = start_byte + entity.length * 2
-			utf_16_link_bytes = utf_16_message_bytes[start_byte:end_byte]
-			urls.append(utf_16_link_bytes.decode('utf-16-le'))
+			urls.append(get_entity_string(message.text, entity))
 		if entity.type == MessageEntity.TEXT_LINK and entity.url is not None:
 			urls.append(entity.url)
+		if entity.type == MessageEntity.TEXT_MENTION and entity.user is not None:
+			user_link = f"tg://user?id={entity.user.id}"
+			urls.append(user_link)
+		if entity.type == MessageEntity.MENTION:
+			username = get_entity_string(message.text, entity)[1:]
+			user_link = f"https://t.me/{username}"
+			urls.append(user_link)
 	return urls
+
+def get_entity_string(message_text: str, entity: MessageEntity) -> str:
+	utf_16_message_bytes = message_text.encode('utf-16-le')
+	start_byte = entity.offset * 2
+	end_byte = start_byte + entity.length * 2
+	return utf_16_message_bytes[start_byte:end_byte].decode('utf-16-le')
 
 class LBUser:
 	__slot__ = ('score', 'rank', 'userid')

--- a/common.py
+++ b/common.py
@@ -184,7 +184,8 @@ def get_urls_from_message(message: Message) -> list[str]:
 			user_link = f"https://t.me/{username}"
 			urls.append(user_link)
 
-	return [normalized for url in urls if (normalized := url_normalize(url)) is not None]
+	normalized_urls = [norm.replace("http://", "https://", 1) if norm.startswith("http://") else norm for url in urls if (norm := url_normalize(url)) is not None]
+	return normalized_urls
 
 def get_entity_string(message_text: str, entity: MessageEntity) -> str:
 	utf_16_message_bytes = message_text.encode('utf-16-le')

--- a/database.py
+++ b/database.py
@@ -1,7 +1,7 @@
 import sqlite3
 from threading import RLock
 
-DB_SCHEME_VERSION = 3
+DB_SCHEME_VERSION = 4
 
 
 class UserDB:
@@ -42,6 +42,9 @@ class UserDB:
 			if user_version < 2:
 				print("upgrading DB to: v2")
 				self.db.execute('''ALTER TABLE users ADD COLUMN vkscore INTEGER DEFAULT 0 CHECK(vkscore >= 0)''')
+			if user_version < 4:
+				print("Clearing badmessages table")
+				self.db.execute('''DELETE FROM badmessages''')
 
 		self.db.execute(f'''PRAGMA user_version = {DB_SCHEME_VERSION}''')
 

--- a/main.py
+++ b/main.py
@@ -2,9 +2,8 @@
 from math import floor, log10
 from datetime import datetime
 from collections.abc import Callable
-from typing import List, Tuple
 
-from telegram import MessageEntity, Update
+from telegram import Update
 from telegram.constants import ParseMode
 from telegram.ext import Application, CallbackContext, CommandHandler, MessageHandler, filters
 from telegram.error import TelegramError
@@ -349,7 +348,7 @@ async def myrank(update: Update, context: CallbackContext) -> None:
 async def on_text_message(update: Update, context: CallbackContext) -> None:
 	if update.message is not None and update.message.text is not None:
 		assert update.message.from_user is not None
-		message_links: List[str] = get_urls_from_message(update.message)
+		message_links: list[str] = get_urls_from_message(update.message)
 		for link in message_links:
 			link_hash: bytes = hashdigest(link)
 			link_badness: int = db.check_message_badness(link_hash)

--- a/main.py
+++ b/main.py
@@ -2,15 +2,16 @@
 from math import floor, log10
 from datetime import datetime
 from collections.abc import Callable
+from typing import List, Tuple
 
-from telegram import Update
+from telegram import MessageEntity, Update
 from telegram.constants import ParseMode
 from telegram.ext import Application, CallbackContext, CommandHandler, MessageHandler, filters
 from telegram.error import TelegramError
 
 import database
 from config import CONFIG
-from common import escape_md, hashdigest, get_mention, filter_chat, is_admin, get_reply_target, \
+from common import escape_md, get_urls_from_message, hashdigest, get_mention, filter_chat, is_admin, get_reply_target, \
 	check_admin_to_user_action, kick_message, Leaderboard
 import common
 
@@ -275,7 +276,7 @@ async def votekick(update: Update, context: CallbackContext) -> None:
 			f'User {get_mention(tuser)} now has {votec}/{votes_required} votes against them\\.{appendix}',
 			parse_mode=ParseMode.MARKDOWN_V2
 		)
-		
+
 		if votec >= votes_required:
 			# don't remove the bot's final message
 			db.add_vk_messages(tuser.id, [update.message.message_id])
@@ -348,18 +349,21 @@ async def myrank(update: Update, context: CallbackContext) -> None:
 async def on_text_message(update: Update, context: CallbackContext) -> None:
 	if update.message is not None and update.message.text is not None:
 		assert update.message.from_user is not None
-		thishash = hashdigest(update.message.text)
-		badness = db.check_message_badness(thishash)
-		if badness >= CONFIG['spam_threshhold']:
-			await kick_message(update.message, context, db)
-		else:
-			common.recent_messages.append((
-				update.message.id,
-				thishash,
-				update.message.from_user.id
-			))
-			if len(common.recent_messages) > CONFIG['message_memory']:
-				common.recent_messages = common.recent_messages[-CONFIG['message_memory']:]
+		message_links: List[str] = get_urls_from_message(update.message)
+		for link in message_links:
+			link_hash: bytes = hashdigest(link)
+			link_badness: int = db.check_message_badness(link_hash)
+			if link_badness >= CONFIG['spam_threshhold']:
+				await kick_message(update.message, context, db)
+				break
+			else:
+				common.recent_message_links.append((
+					update.message.id,
+					link_hash,
+					update.message.from_user.id
+				))
+				if len(common.recent_message_links) > CONFIG['message_memory']:
+					common.recent_message_links = common.recent_message_links[-CONFIG['message_memory']:]
 
 print("starting polling")
 application.run_polling()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 python-telegram-bot>=20.0
+url-normalize>=2.2.1
 # optional for deleting messages on a timer
 # python-telegram-bot[job-queue]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 python-telegram-bot>=20.0
-url-normalize>=2.2.1
 # optional for deleting messages on a timer
 # python-telegram-bot[job-queue]


### PR DESCRIPTION
- Shift anti-spam logic from hashing whole messages to tracking individual URLs.
- Implement UTF-16 aware URL extraction from URL and TEXT_LINK message entities.
- Update recent_message_links to store per-link metadata (message_id, link_hash, userid).
- Refactor kick_message to identify and clear all historical messages containing a flagged link.

Not sure how to test all this stuff, i dot really have access to additional telegram accounts
Closes #26